### PR TITLE
Use tls.TLSSocket in few HTTP related stuff

### DIFF
--- a/library/http.lua
+++ b/library/http.lua
@@ -14,7 +14,7 @@ local http = {}
 ---@field url? string
 ---@field statusCode? httpCodec_code
 ---@field statusMessage? httpCodec_reason
----@field socket luvit.net.Socket
+---@field socket luvit.net.Socket|luvit.tls.TLSSocket
 ---Emitted on error, as well as on `Emitter:wrap()`.
 ---@field on fun(self: luvit.http.IncomingMessage, name: 'error', callback: fun(err: string|luvit.core.Error))
 ---Emitted on error, as well as on `Emitter:wrap()`.
@@ -67,7 +67,7 @@ function IncomingMessage:_read() end
 ---@class luvit.http.ServerResponse: luvit.stream.Writable
 ---Override this in the instance to not send the date.
 ---@field sendDate boolean
----@field socket luvit.net.Socket
+---@field socket luvit.net.Socket|luvit.tls.TLSSocket
 ---@field headersSent boolean
 ---@field headers table
 ---@field _extra_http table

--- a/library/https.lua
+++ b/library/https.lua
@@ -5,21 +5,21 @@
 local https = {}
 
 ---
----@param options {secureContext?: luvit.tls.Credential, secureProtocol?: 'SSLv3'|'SSLv23'|'SSLv2'|'TSLv1'|'TSLv1_1'|'TSLv1_2'|'TLS'|'DTLSv1'|'DTLSv1_2', ciphers?: string, secureOptions?: integer, rejectUnauthorized?: boolean, key?: string, cert?: string, ca?: string, handle?: luvit.net.Socket, secureContext?: unknown, server?: boolean, requestCert?: boolean, rejectUnauthorized?: boolean}
+---@param options {secureContext?: luvit.tls.Credential, secureProtocol?: 'SSLv3'|'SSLv23'|'SSLv2'|'TSLv1'|'TSLv1_1'|'TSLv1_2'|'TLS'|'DTLSv1'|'DTLSv1_2', ciphers?: string, secureOptions?: integer, rejectUnauthorized?: boolean, key?: string, cert?: string, ca?: string, handle?: luvit.tls.TLSSocket, secureContext?: unknown, server?: boolean, requestCert?: boolean, rejectUnauthorized?: boolean}
 ---@param onRequest http_onRequest
 ---@return luvit.tls.Server
 ---@nodiscard
 function https.createServer(options, onRequest) end
 
 ---
----@param options string|{headers?: table, host?: string, method?: httpCodec_method, path?: string, port?: integer, socket?: luvit.net.Socket}
+---@param options string|{headers?: table, host?: string, method?: httpCodec_method, path?: string, port?: integer, socket?: luvit.tls.TLSSocket}
 ---@param callback? fun(res: luvit.http.IncomingMessage)
 ---@return luvit.http.ClientRequest
 ---@nodiscard
 function https.request(options, callback) end
 
 ---
----@param options string|{headers?: table, host?: string, method?: httpCodec_method, path?: string, port?: integer, socket?: luvit.net.Socket}
+---@param options string|{headers?: table, host?: string, method?: httpCodec_method, path?: string, port?: integer, socket?: luvit.tls.TLSSocket}
 ---@param onResponse? fun(res: luvit.http.IncomingMessage)
 ---@return luvit.http.ClientRequest
 function https.get(options, onResponse) end


### PR DESCRIPTION
First commit is most likely useful. https.lua only supports HTTPS, so it obviously uses tls.TLSSocket. Second one can be debatable though, but I see use cases for this sometimes. Feel free to only include the first one though. (I could go make a second PR with only the first commit, or you can have fun with Git.)